### PR TITLE
Fix typo in configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Vehicle-Longitudinal-Control/
 
 ## 六、参数配置 (Configuration)
 
-* `configs/vehicle_params.py`：集中管理车辆质量、空气阻力系数、滚动阻力系数、执行器自然频率／阻尼比、最大驱动力／制动力、ABS 参数等语塞变量；
+* `configs/vehicle_params.py`：集中管理车辆质量、空气阻力系数、滚动阻力系数、执行器自然频率／阻尼比、最大驱动力／制动力、ABS 参数等参数变量；
 * 可在 GUI 中修改参数实现权重和限幅参数的动态调整。
 
 ## 七、结果可视化 (Visualization)


### PR DESCRIPTION
## Summary
- fix typo around parameter management in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fc60d6ebc8320b56bb8609d06468c